### PR TITLE
Only make executing workspace PVC read-write, other can be read-only

### DIFF
--- a/pycalrissian/job.py
+++ b/pycalrissian/job.py
@@ -343,7 +343,6 @@ class CalrissianJob:
                 efs_volume_mount = client.V1VolumeMount(
                     mount_path=f"/workspace/{pvc_mount_path}",
                     name=pv_name,
-                    read_only=False,
                 )
 
                 logger.info(f"Mounting calling workspace EFS volume {pv_name} with claim {pvc_name} at {efs_volume_mount.mount_path}.")


### PR DESCRIPTION
- read_only defaults to True
- Only the executing workspace can be altered, otherwise only used by stagein and stageout which only need read access